### PR TITLE
Remove minheight, add current & mount props

### DIFF
--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -22,7 +22,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-transition-link',
       options: {
-        layout: false,
+        layout: require.resolve(`./src/layout`),
       },
     },
     // 'gatsby-plugin-transition-link',

--- a/example/src/layout/index.js
+++ b/example/src/layout/index.js
@@ -1,0 +1,8 @@
+import React from 'react'
+
+export default ({ children }) => (
+  <>
+    {children}
+    <h1 style={{ textAlign: 'center' }}>persistent footer!</h1>
+  </>
+)

--- a/example/src/pages/index.js
+++ b/example/src/pages/index.js
@@ -73,10 +73,10 @@ class Index extends Component {
           <AniLink swipe to="/page-2" direction="right" top="exit">
             Go to page 2 with a swipe right
           </AniLink>
-          <br />
+          {/* <br />
           <AniLink swipe to="/page-2" direction="up" top="exit">
             Go to page 2 with a swipe up
-          </AniLink>
+          </AniLink> */}
           <br />
           <AniLink swipe to="/page-2" direction="down" top="exit">
             Go to page 2 with a swipe down

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "license": "MIT",
   "scripts": {
     "copy-files": "mkdir lib || true && cp .eslintrc.json readme.md package.json lib",
-    "build": "yarn copy-files && babel src --out-dir lib --ignore **/__tests__",
-    "watch": "yarn copy-files && babel -w src --out-dir lib --ignore **/__tests__",
+    "build": "yarn copy-files && babel src --out-dir lib --copy-files --ignore **/__tests__",
+    "watch": "yarn copy-files && babel -w src --out-dir lib --copy-files --ignore **/__tests__",
     "prepare-files": "cross-env NODE_ENV=production yarn build",
     "publish-repo": "yarn copy-files && cd lib && npm publish && cd ../",
     "publish-patch": "yarn prepare-files && npx json-bump --patch=1 package.json && yarn publish-repo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-transition-link",
-  "version": "1.4.7",
+  "version": "1.5.0",
   "description": "A link component for page transitions in gatsby.",
   "repository": "https://github.com/TylerBarnes/gatsby-plugin-transition-link",
   "homepage": "https://gatsby-plugin-transition-link.netlify.com/",

--- a/src/AniLink/Cover.js
+++ b/src/AniLink/Cover.js
@@ -1,7 +1,5 @@
 import React, { Component } from "react";
-import TransitionLink, {
-  TransitionPortal
-} from "gatsby-plugin-transition-link";
+import TransitionLink, { TransitionPortal } from "../";
 import { TimelineMax, Power1 } from "gsap";
 
 export default class Cover extends Component {

--- a/src/AniLink/Fade.js
+++ b/src/AniLink/Fade.js
@@ -1,5 +1,5 @@
 import React from "react";
-import TransitionLink from "gatsby-plugin-transition-link";
+import TransitionLink from "../";
 import { TimelineMax } from "gsap";
 
 const fade = ({ exit: { length }, node, direction }) => {

--- a/src/AniLink/PaintDrip.js
+++ b/src/AniLink/PaintDrip.js
@@ -1,7 +1,7 @@
 // This was made using the code borrowed from this beautiful codepen!
 // https://codepen.io/osublake/pen/eNrQqV?editors=0010
 import React, { Component } from "react";
-import TransitionLink from "gatsby-plugin-transition-link";
+import TransitionLink from "../";
 import { TimelineMax, Power1 } from "gsap";
 import convert from "color-convert";
 

--- a/src/AniLink/Swipe.js
+++ b/src/AniLink/Swipe.js
@@ -1,5 +1,5 @@
 import React from "react";
-import TransitionLink from "gatsby-plugin-transition-link";
+import TransitionLink from "../";
 import { TimelineMax, Power1 } from "gsap";
 
 const boxShadow = "0 0 100px 10px rgba(0, 0, 0, 0.12941176470588237)";

--- a/src/AniLink/index.js
+++ b/src/AniLink/index.js
@@ -3,7 +3,7 @@ import Cover from "./Cover";
 import Fade from "./Fade";
 import PaintDrip from "./PaintDrip";
 import SwipeOver from "./Swipe";
-import TransitionLink from "gatsby-plugin-transition-link";
+import TransitionLink from "../";
 
 export default function DefaultTransition(props) {
   return (

--- a/src/components/TransitionHandler.js
+++ b/src/components/TransitionHandler.js
@@ -9,34 +9,9 @@ import { getMs } from "../utils/secondsMs";
 import { onEnter } from "../functions/onEnter";
 import { onExit } from "../functions/onExit";
 import { LayoutComponent as Layout } from "./Layout";
-import pageMinHeight from "../functions/pageMinHeight";
 
 const DelayedTransition = delayTransitionRender(Transition);
 export default class TransitionHandler extends Component {
-  constructor(props) {
-    super(props);
-
-    this.wrapper = React.createRef();
-    this.updatePageMinHeight = this.updatePageMinHeight.bind(this);
-  }
-  componentDidMount() {
-    this.updatePageMinHeight();
-    window.addEventListener("resize", this.updatePageMinHeight);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("resize", this.updatePageMinHeight);
-  }
-
-  updatePageMinHeight() {
-    setTimeout(
-      () =>
-        pageMinHeight({
-          node: this.wrapper
-        }),
-      1
-    );
-  }
   render() {
     const { props } = this;
     const { children } = props;
@@ -81,7 +56,6 @@ export default class TransitionHandler extends Component {
                           exitProps,
                           pathname,
                           updateContext,
-                          pageMinHeight,
                           e
                         })
                       }
@@ -129,7 +103,6 @@ export default class TransitionHandler extends Component {
 
                         return (
                           <div
-                            ref={n => (this.wrapper = n)}
                             className="tl-wrapper"
                             style={{
                               position: "absolute",

--- a/src/components/TransitionHandler.js
+++ b/src/components/TransitionHandler.js
@@ -10,6 +10,8 @@ import { onEnter } from "../functions/onEnter";
 import { onExit } from "../functions/onExit";
 import { LayoutComponent as Layout } from "./Layout";
 
+import "../style.css";
+
 const DelayedTransition = delayTransitionRender(Transition);
 export default class TransitionHandler extends Component {
   render() {
@@ -72,11 +74,11 @@ export default class TransitionHandler extends Component {
                       }
                     >
                       {transitionStatus => {
-                        const transitionState = returnTransitionState({
-                          inTransition,
-                          location: props.location,
-                          transitionIdHistory,
-                          transitionStatus,
+                        const mount =
+                          transitionStatus === "entering" ||
+                          transitionStatus === "entered";
+
+                        const states = {
                           entry: {
                             state: entryState,
                             delay: entryDelay,
@@ -87,35 +89,39 @@ export default class TransitionHandler extends Component {
                             delay: exitDelay,
                             length: exitLength
                           }
+                        };
+
+                        const current = mount ? states.entry : states.exit;
+
+                        const transitionState = returnTransitionState({
+                          inTransition,
+                          location: props.location,
+                          transitionIdHistory,
+                          transitionStatus,
+                          current,
+                          mount,
+                          ...states
                         });
 
                         const exitZindex = exitProps.zIndex || 0;
                         const entryZindex = entryProps.zIndex || 1;
 
-                        const childWithTransitionState = React.Children.map(
-                          children,
-                          child => {
-                            return React.cloneElement(child, {
-                              ...transitionState
-                            });
-                          }
-                        );
-
                         return (
                           <div
-                            className="tl-wrapper"
+                            className={`tl-wrapper ${
+                              mount
+                                ? "tl-wrapper--mount"
+                                : "tl-wrapper--unmount"
+                            } tl-wrapper-status--${transitionStatus}`}
                             style={{
-                              position: "absolute",
-                              width: "100%",
-                              zIndex:
-                                transitionStatus === "entering" ||
-                                transitionStatus === "entered"
-                                  ? entryZindex
-                                  : exitZindex
+                              zIndex: mount ? entryZindex : exitZindex
                             }}
                           >
                             <PublicProvider value={{ ...transitionState }}>
-                              {childWithTransitionState}
+                              {/* pass transition state to page/template */}
+                              {React.cloneElement(children, {
+                                ...transitionState
+                              })}
                             </PublicProvider>
                           </div>
                         );

--- a/src/context/InternalProvider.js
+++ b/src/context/InternalProvider.js
@@ -6,7 +6,6 @@ class InternalProvider extends Component {
   state = {
     inTransition: false,
     transitionIdHistory: [],
-    wrapperMinHeight: false,
     // event
     e: false,
     // exit

--- a/src/functions/onEnter.js
+++ b/src/functions/onEnter.js
@@ -5,12 +5,8 @@ const onEnter = ({
   entryProps,
   exitProps,
   pathname,
-  pageMinHeight,
-  updateContext,
   e
 }) => {
-  pageMinHeight({ node, updateContext });
-
   if (inTransition) {
     window.scrollTo(0, 0);
   } else {

--- a/src/functions/pageMinHeight.js
+++ b/src/functions/pageMinHeight.js
@@ -1,8 +1,0 @@
-// this function is used to set the outerwrapper height to keep the page from jumping up on save during development.
-export default function pageMinHeight({ node, updateContext }) {
-  const minHeight = node.offsetHeight;
-  if (minHeight > 0) {
-    sessionStorage.setItem("wrapperMinHeight", node.offsetHeight);
-    updateContext && updateContext({ wrapperMinHeight: node.offsetHeight });
-  }
-}

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,10 @@
+.tl-wrapper {
+  width: 100%;
+  float: left;
+  position: relative;
+}
+
+.tl-wrapper + .tl-wrapper {
+  margin-left: -100%;
+  margin-right: 0;
+}

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -1,34 +1,12 @@
 const React = require("react");
 const TransitionHandler = require("./components/TransitionHandler").default;
 const InternalProvider = require("./context/InternalProvider").default;
-const Consumer = require("./context/createTransitionContext").Consumer;
 
 // eslint-disable-next-line react/prop-types,react/display-name
 module.exports = ({ element, props }) => {
-  const sessionMinHeight =
-    typeof sessionStorage !== "undefined"
-      ? sessionStorage.getItem("wrapperMinHeight")
-      : false;
   return (
     <InternalProvider>
-      <Consumer>
-        {({ wrapperMinHeight, inTransition }) => {
-          const minHeight = wrapperMinHeight
-            ? `${wrapperMinHeight}px`
-            : `${!!sessionMinHeight ? sessionMinHeight + "px" : false}`;
-          return (
-            <div
-              style={{
-                position: "relative",
-                zIndex: 0,
-                minHeight: inTransition ? false : minHeight
-              }}
-            >
-              <TransitionHandler {...props}>{element}</TransitionHandler>
-            </div>
-          );
-        }}
-      </Consumer>
+      <TransitionHandler {...props}>{element}</TransitionHandler>
     </InternalProvider>
   );
 };


### PR DESCRIPTION
This removes the minheight wrapper in favour of using position relative with negative margins to overlap pages.

It also adds a couple new props for pages and the TransitionState component, mount and current.

mount tells you wether a page is being mounted or is mounted, it's a boolean. 
current gives you the exit or entry props depending on wether the current page is mounting or unmounting.