### PR TITLE
feat: add trigger prop to TransitionLink.

### DIFF
--- a/src/components/TransitionHandler.js
+++ b/src/components/TransitionHandler.js
@@ -34,6 +34,7 @@ export default class TransitionHandler extends Component {
           transitionIdHistory,
           inTransition,
           updateContext,
+          triggerResolve,
           e
         }) => {
           return (
@@ -61,6 +62,7 @@ export default class TransitionHandler extends Component {
                             exitProps,
                             pathname,
                             updateContext,
+                            triggerResolve,
                             e
                           })
                         }
@@ -73,6 +75,7 @@ export default class TransitionHandler extends Component {
                             exitTrigger,
                             entryProps,
                             exitProps,
+                            triggerResolve,
                             e
                           })
                         }

--- a/src/components/TransitionLink.js
+++ b/src/components/TransitionLink.js
@@ -14,6 +14,7 @@ const TransitionLink = ({
   style,
   className,
   onClick,
+  trigger,
   ...rest
 }) => {
   return (
@@ -29,11 +30,12 @@ const TransitionLink = ({
               to,
               exit,
               entry,
+              trigger,
               ...context
-            })
+            });
 
-            if (typeof onClick === 'function') {
-              onClick(event)
+            if (typeof onClick === "function") {
+              onClick(event);
             }
           }}
           to={to} // use gatsby link so prefetching still happens. this is prevent defaulted in triggertransition

--- a/src/context/InternalProvider.js
+++ b/src/context/InternalProvider.js
@@ -24,6 +24,29 @@ class InternalProvider extends Component {
     updateContext: obj => this.setState(obj)
   };
 
+  componentDidMount() {
+    let exitResolve;
+    const exitPromise = new Promise(resolve => {
+      exitResolve = resolve;
+    });
+
+    let entryResolve;
+    const entryPromise = new Promise(resolve => {
+      entryResolve = resolve;
+    });
+
+    this.state.updateContext({
+      triggerResolve: {
+        entry: entryResolve,
+        exit: exitResolve
+      },
+      pages: {
+        exit: exitPromise,
+        entry: entryPromise
+      }
+    });
+  }
+
   render() {
     return <Provider value={this.state}>{this.props.children}</Provider>;
   }

--- a/src/functions/onEnter.js
+++ b/src/functions/onEnter.js
@@ -4,6 +4,7 @@ const onEnter = ({
   entryTrigger,
   entryProps,
   exitProps,
+  triggerResolve,
   pathname,
   e
 }) => {
@@ -16,6 +17,13 @@ const onEnter = ({
   }
 
   if (!inTransition) return;
+
+  const { trigger: removed, ...entryPropsTrimmed } = entryProps;
+
+  triggerResolve.entry({
+    ...entryPropsTrimmed,
+    node
+  });
 
   entryTrigger &&
     typeof entryTrigger === "function" &&

--- a/src/functions/onExit.js
+++ b/src/functions/onExit.js
@@ -4,9 +4,17 @@ const onExit = ({
   exitTrigger,
   entryProps,
   exitProps,
+  triggerResolve,
   e
 }) => {
   if (!inTransition) return;
+
+  const { trigger: removed, ...exitPropsTrimmed } = exitProps;
+
+  triggerResolve.exit({
+    ...exitPropsTrimmed,
+    node
+  });
 
   return (
     exitTrigger &&

--- a/src/utils/triggerTransition.js
+++ b/src/utils/triggerTransition.js
@@ -10,6 +10,8 @@ const triggerTransition = ({
   entry = {},
   inTransition,
   transitionIdHistory,
+  pages,
+  trigger,
   updateContext
 }) => {
   event.persist();
@@ -27,6 +29,8 @@ const triggerTransition = ({
     exitLength: 0,
     exitState: {}
   });
+
+  trigger(pages);
 
   const {
     length: exitLength = 0,


### PR DESCRIPTION
This prop takes an async function with the entering and exiting pages as it's arguments. This allows awaiting each node so that a single transition can be made using both nodes. It allows for flip animations between pages.

For #53 

I think for #53, there still needs to be a way to immediately render the entering page but just have it as `opacity: 0`. This should work well for now though!