### PR TITLE
add appear after prop to temporarily hide a page during animation

### DIFF
--- a/src/components/TransitionHandler.js
+++ b/src/components/TransitionHandler.js
@@ -35,6 +35,7 @@ export default class TransitionHandler extends Component {
           inTransition,
           updateContext,
           triggerResolve,
+          appearAfter,
           e
         }) => {
           return (
@@ -46,6 +47,7 @@ export default class TransitionHandler extends Component {
                       <DelayedTransition
                         key={pathname} // we're using seconds but transitiongroup uses ms
                         delay={getMs(entryDelay)}
+                        appearAfter={getMs(appearAfter)}
                         timeout={{
                           enter: getMs(entryLength),
                           exit: getMs(exitLength)

--- a/src/components/delayTransitionRender.js
+++ b/src/components/delayTransitionRender.js
@@ -10,24 +10,37 @@ export default function delayTransitionRender(WrappedComponent) {
         // if there is a delay, set shouldRender to false
         // then in componentdid mount shouldRender becomes true
         // after the delay.
-        shouldRender: !!!this.props.delay
+        shouldRender: !!!this.props.delay,
+        shouldBeVisible: !!!this.props.appearAfter
       };
     }
 
     componentDidMount() {
-      this.timeout = setTimeout(
+      this.renderTimeout = setTimeout(
         () => this.setState({ shouldRender: true }),
         this.props.delay
+      );
+
+      this.appearTimeout = setTimeout(
+        () => this.setState({ shouldBeVisible: true }),
+        this.props.delay + this.props.appearAfter
       );
     }
 
     componentWillUnmount() {
-      clearTimeout(this.timeout);
+      clearTimeout(this.renderTimeout);
+      clearTimeout(this.appearTimeout);
     }
 
     render() {
       return this.state.shouldRender || typeof window === `undefined` ? (
-        <WrappedComponent {...this.props} />
+        <span
+          style={{
+            opacity: this.state.shouldBeVisible ? 1 : 0
+          }}
+        >
+          <WrappedComponent {...this.props} />
+        </span>
       ) : null;
     }
   }

--- a/src/utils/triggerTransition.js
+++ b/src/utils/triggerTransition.js
@@ -28,6 +28,7 @@ const triggerTransition = ({
     inTransition: true,
     exitDelay: 0,
     exitLength: 0,
+    appearAfter: 0,
     exitState: {}
   });
 
@@ -45,7 +46,8 @@ const triggerTransition = ({
     length: entryLength = 1, // this allows scrollposition to be reset when there is no transition.
     delay: entryDelay = 0,
     state: entryState = {},
-    trigger: entryTrigger = () => {}
+    trigger: entryTrigger = () => {},
+    appearAfter = 0
   } = entry;
 
   updateContext({
@@ -55,6 +57,7 @@ const triggerTransition = ({
     exitDelay: exitDelay,
     entryProps: entry,
     exitProps: exit,
+    appearAfter,
     exitTrigger: (exit, node, e) => exitTrigger(exit, node, e),
     entryTrigger: (entry, node, e) => entryTrigger(entry, node, e),
     e: event
@@ -81,6 +84,7 @@ const triggerTransition = ({
     () =>
       updateContext({
         entryDelay: 0,
+        appearAfter: 0,
         entryLength: 0
       }),
     getMs(exitDelay + entryDelay + entryLength)


### PR DESCRIPTION
This is to be used in conjunction with the new trigger prop. The idea is that we can render the page immediately but just hide it for x seconds so that elements can be measured.

fixes #53 