### PR TITLE
fix: pass all available gatsby link props through

### DIFF
--- a/src/components/TransitionLink.js
+++ b/src/components/TransitionLink.js
@@ -11,19 +11,25 @@ const TransitionLink = ({
   exit,
   entry,
   activeStyle,
+  partiallyActive,
   style,
   className,
+  activeClassName,
+  state,
   onClick,
   trigger,
+  replace,
   ...rest
 }) => {
   return (
     <Consumer>
       {({ ...context }) => (
         <Link
-          activeStyle={activeStyle}
           style={style}
+          activeStyle={activeStyle}
           className={className}
+          activeClassName={activeClassName}
+          partiallyActive={partiallyActive}
           onClick={event => {
             triggerTransition({
               event,
@@ -31,6 +37,8 @@ const TransitionLink = ({
               exit,
               entry,
               trigger,
+              replace,
+              linkState: state,
               ...context
             });
 

--- a/src/utils/triggerTransition.js
+++ b/src/utils/triggerTransition.js
@@ -13,7 +13,9 @@ const triggerTransition = ({
   transitionIdHistory,
   pages,
   trigger,
-  updateContext
+  updateContext,
+  linkState,
+  replace
 }) => {
   event.persist();
   event.preventDefault();
@@ -63,10 +65,18 @@ const triggerTransition = ({
     e: event
   });
 
+  // after exitDelay
   setTimeout(() => {
-    // after exitDelay
     const transitionId = random(10000, 99999, false);
-    navigate(to, { state: { transitionId: transitionId } });
+
+    navigate(to, {
+      state: {
+        transitionId,
+        ...linkState
+      },
+      replace
+    });
+
     updateContext({
       exitState: exitState,
       transitionIdHistory: [...transitionIdHistory, transitionId]


### PR DESCRIPTION
fixes #72 

All props are being forwarded to the Link component but navigation actually happens inside of `triggerTransition` using the `navigate` function from gatsby, so that needed to be wired up manually.
