### PR TITLE
only disable shouldUpdateScroll if a transition is underway.

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -2,7 +2,7 @@ const { navigate } = require("gatsby");
 
 exports.wrapPageElement = require(`./wrap-page`);
 
-exports.shouldUpdateScroll = () => false;
+exports.shouldUpdateScroll = () => !window.__tl_inTransition;
 
 exports.onPreRouteUpdate = ({ location }) => {
   // prevent the back button during transitions as it breaks pages


### PR DESCRIPTION
fixes #45 to allow `gatsby-link` and `transition-link` to coincide peacefully.