### PR TITLE
feat: add forwardRef to TransitionLink

### DIFF
--- a/src/AniLink/MorphTo.js
+++ b/src/AniLink/MorphTo.js
@@ -2,7 +2,7 @@ import React from "react";
 import TransitionLink from "gatsby-plugin-transition-link";
 import { TimelineMax } from "gsap";
 
-const MorphTo = ({ children, to, duration, morph, ...props }) => (
+const MorphTo = ({ children, to, duration, morph }) => (
   <TransitionLink
     to={to}
     exit={{
@@ -28,7 +28,6 @@ const MorphTo = ({ children, to, duration, morph, ...props }) => (
         height: finalMeasurements.height
       });
     }}
-    {...props}
   >
     {children}
   </TransitionLink>

--- a/src/AniLink/MorphTo.js
+++ b/src/AniLink/MorphTo.js
@@ -2,7 +2,7 @@ import React from "react";
 import TransitionLink from "gatsby-plugin-transition-link";
 import { TimelineMax } from "gsap";
 
-const MorphTo = ({ children, to, duration, morph }) => (
+const MorphTo = ({ children, to, duration, morph, ...props }) => (
   <TransitionLink
     to={to}
     exit={{
@@ -28,6 +28,7 @@ const MorphTo = ({ children, to, duration, morph }) => (
         height: finalMeasurements.height
       });
     }}
+    {...props}
   >
     {children}
   </TransitionLink>

--- a/src/components/TransitionLink.js
+++ b/src/components/TransitionLink.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "gatsby";
 
@@ -6,27 +6,24 @@ import { shouldNavigate } from "../utils/shouldNavigate";
 import { triggerTransition } from "../utils/triggerTransition";
 import { Consumer } from "../context/createTransitionContext";
 
-if (typeof forwardRef === "undefined") {
-  forwardRef = C => C;
-}
+const TransitionLink = ({
+    to,
+    children,
+    exit,
+    entry,
+    activeStyle,
+    partiallyActive,
+    style,
+    className,
+    activeClassName,
+    state,
+    onClick,
+    trigger,
+    replace,
+    innerRef,
+    ...rest
+  }) => {
 
-const TransitionLink = forwardRef(({
-  to,
-  children,
-  exit,
-  entry,
-  activeStyle,
-  partiallyActive,
-  style,
-  className,
-  activeClassName,
-  state,
-  onClick,
-  trigger,
-  replace,
-  innerRef,
-  ...rest
-}, ref) => {
   return (
     <Consumer>
       {({ ...context }) => (
@@ -57,7 +54,7 @@ const TransitionLink = forwardRef(({
             }
           }}
           to={to} // use gatsby link so prefetching still happens. this is prevent defaulted in triggertransition
-          ref={ref || innerRef}
+          ref={innerRef}
           {...rest}
         >
           {children}
@@ -65,7 +62,7 @@ const TransitionLink = forwardRef(({
       )}
     </Consumer>
   );
-});
+}
 
 TransitionLink.propTypes = {
   to: PropTypes.string.isRequired,

--- a/src/components/TransitionLink.js
+++ b/src/components/TransitionLink.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import PropTypes from "prop-types";
 import { Link } from "gatsby";
 
@@ -6,24 +6,27 @@ import { shouldNavigate } from "../utils/shouldNavigate";
 import { triggerTransition } from "../utils/triggerTransition";
 import { Consumer } from "../context/createTransitionContext";
 
-const TransitionLink = ({
-    to,
-    children,
-    exit,
-    entry,
-    activeStyle,
-    partiallyActive,
-    style,
-    className,
-    activeClassName,
-    state,
-    onClick,
-    trigger,
-    replace,
-    innerRef,
-    ...rest
-  }) => {
+if (typeof forwardRef === "undefined") {
+  forwardRef = C => C;
+}
 
+const TransitionLink = forwardRef(({
+  to,
+  children,
+  exit,
+  entry,
+  activeStyle,
+  partiallyActive,
+  style,
+  className,
+  activeClassName,
+  state,
+  onClick,
+  trigger,
+  replace,
+  innerRef,
+  ...rest
+}, ref) => {
   return (
     <Consumer>
       {({ ...context }) => (
@@ -54,7 +57,7 @@ const TransitionLink = ({
             }
           }}
           to={to} // use gatsby link so prefetching still happens. this is prevent defaulted in triggertransition
-          ref={innerRef}
+          ref={ref || innerRef}
           {...rest}
         >
           {children}
@@ -62,7 +65,7 @@ const TransitionLink = ({
       )}
     </Consumer>
   );
-}
+});
 
 TransitionLink.propTypes = {
   to: PropTypes.string.isRequired,

--- a/src/components/TransitionLink.js
+++ b/src/components/TransitionLink.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import PropTypes from "prop-types";
 import { Link } from "gatsby";
 
@@ -6,7 +6,11 @@ import { shouldNavigate } from "../utils/shouldNavigate";
 import { triggerTransition } from "../utils/triggerTransition";
 import { Consumer } from "../context/createTransitionContext";
 
-const TransitionLink = ({
+if (typeof forwardRef === "undefined") {
+  forwardRef = C => C;
+}
+
+const TransitionLink = forwardRef(({
   to,
   children,
   exit,
@@ -20,8 +24,9 @@ const TransitionLink = ({
   onClick,
   trigger,
   replace,
+  innerRef,
   ...rest
-}) => {
+}, ref) => {
   return (
     <Consumer>
       {({ ...context }) => (
@@ -52,6 +57,7 @@ const TransitionLink = ({
             }
           }}
           to={to} // use gatsby link so prefetching still happens. this is prevent defaulted in triggertransition
+          ref={ref || innerRef}
           {...rest}
         >
           {children}
@@ -59,7 +65,7 @@ const TransitionLink = ({
       )}
     </Consumer>
   );
-};
+});
 
 TransitionLink.propTypes = {
   to: PropTypes.string.isRequired,


### PR DESCRIPTION
Based on reach router implementation: https://github.com/reach/router/blob/master/src/index.js#L368

https://github.com/TylerBarnes/gatsby-plugin-transition-link/issues/98#issue-453645748