### PR TITLE
fix: handles 'sessionStorage' error when cookies are disabled

### DIFF
--- a/src/functions/onEnter.js
+++ b/src/functions/onEnter.js
@@ -17,11 +17,13 @@ const onEnter = ({
       window.scrollTo(0, 0);
     }, appearAfter);
   } else {
-    const storageKey = `@@scroll|${pathname}`;
+    let position = [0, 0];
     try {
-      const savedPosition = sessionStorage.getItem(storageKey);
-      window.scrollTo(...JSON.parse(savedPosition));
-    } catch (e) {}
+      const storageKey = `@@scroll|${pathname}`;
+      position = JSON.parse(sessionStorage.getItem(storageKey));
+    } finally {
+      window.scrollTo(...position);
+    }
   }
 
   if (!inTransition) return;

--- a/src/functions/onEnter.js
+++ b/src/functions/onEnter.js
@@ -17,10 +17,15 @@ const onEnter = ({
       window.scrollTo(0, 0);
     }, appearAfter);
   } else {
+    // If session storage fails due to cookies being disabled, 
+    // scroll to the top after every navigation
     let position = [0, 0];
     try {
       const storageKey = `@@scroll|${pathname}`;
       position = JSON.parse(sessionStorage.getItem(storageKey));
+    }
+    catch(e) {
+      console.warn(`[gatsby-plugin-transition-link] Unable to save state in sessionStorage; sessionStorage is not available.`)
     } finally {
       window.scrollTo(...position);
     }

--- a/src/functions/onEnter.js
+++ b/src/functions/onEnter.js
@@ -18,8 +18,10 @@ const onEnter = ({
     }, appearAfter);
   } else {
     const storageKey = `@@scroll|${pathname}`;
-    const savedPosition = sessionStorage.getItem(storageKey);
-    window.scrollTo(...JSON.parse(savedPosition));
+    try {
+      const savedPosition = sessionStorage.getItem(storageKey);
+      window.scrollTo(...JSON.parse(savedPosition));
+    } catch (e) {}
   }
 
   if (!inTransition) return;


### PR DESCRIPTION
When navigating back/forward in Chrome with the setting "block third-party cookies" enabled, this error will cause the screen to blank:

`Uncaught DOMException: Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.`. 

This PR scrolls the page to the top in this case, but perhaps there's a different workaround that might be preferable?