### PR TITLE
Feature/plugin option disable page prop injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"release": "standard-version",
 		"copy-files": "mkdir lib || true && cp .eslintrc.json readme.md package.json lib",
 		"build": "yarn copy-files && babel src --out-dir lib --copy-files --ignore **/__tests__",
-		"watch": "yarn copy-files && babel -w src --out-dir lib --copy-files --ignore **/__tests__",
+		"watch": "yarn copy-files && babel -w src --out-dir lib --copy-files --ignore **/__tests__ --verbose",
 		"npm-publish": "git push --follow-tags origin master && yarn build && cd lib && npm publish && cd ../"
 	},
 	"devDependencies": {

--- a/src/components/TransitionHandler.js
+++ b/src/components/TransitionHandler.js
@@ -1,141 +1,161 @@
-import React, { Component } from "react";
-import { Transition, TransitionGroup } from "react-transition-group";
-import { Location } from "@reach/router";
+import React, { Component } from "react"
+import { Transition, TransitionGroup } from "react-transition-group"
+import { Location } from "@reach/router"
 
-import TransitionRenderer from "./TransitionRenderer";
-import { LayoutComponent as Layout } from "./Layout";
-import delayTransitionRender from "./delayTransitionRender";
-import { Consumer } from "../context/createTransitionContext";
-import { returnTransitionState } from "../utils/returnTransitionState";
-import { onEnter } from "../functions/onEnter";
-import { onExit } from "../functions/onExit";
-import { getMs } from "../utils/secondsMs";
+import TransitionRenderer from "./TransitionRenderer"
+import { LayoutComponent as Layout } from "./Layout"
+import delayTransitionRender from "./delayTransitionRender"
+import { Consumer } from "../context/createTransitionContext"
+import { returnTransitionState } from "../utils/returnTransitionState"
+import { onEnter } from "../functions/onEnter"
+import { onExit } from "../functions/onExit"
+import { getMs } from "../utils/secondsMs"
 
-import "../style.css";
+import "../style.css"
 
-const DelayedTransition = delayTransitionRender(Transition);
+const DelayedTransition = delayTransitionRender(Transition)
 export default class TransitionHandler extends Component {
-  render() {
-    const { props } = this;
-    const { children } = props;
-    return (
-      <Consumer>
-        {({
-          exitDelay,
-          exitLength,
-          exitState,
-          entryDelay,
-          entryLength,
-          entryState,
-          entryTrigger,
-          entryProps,
-          exitTrigger,
-          exitProps,
-          transitionIdHistory,
-          inTransition,
-          updateContext,
-          triggerResolve,
-          appearAfter,
-          e
-        }) => {
-          return (
-            <Location>
-              {({ location: { action, pathname } }) => (
-                <Layout {...props}>
-                  <div className="tl-edges">
-                    <TransitionGroup component={null}>
-                      <DelayedTransition
-                        key={pathname} // we're using seconds but transitiongroup uses ms
-                        delay={getMs(entryDelay)}
-                        timeout={{
-                          enter: getMs(entryLength),
-                          exit: getMs(exitLength)
-                        }}
-                        onEnter={node =>
-                          !!node &&
-                          !window.__tl_back_button_pressed &&
-                          onEnter({
-                            node,
-                            action,
-                            inTransition,
-                            entryTrigger,
-                            entryProps,
-                            exitProps,
-                            pathname,
-                            updateContext,
-                            triggerResolve,
-                            appearAfter: getMs(appearAfter),
-                            e
-                          })
-                        }
-                        onExit={node =>
-                          !!node &&
-                          !window.__tl_back_button_pressed &&
-                          onExit({
-                            node,
-                            inTransition,
-                            exitTrigger,
-                            entryProps,
-                            exitProps,
-                            triggerResolve,
-                            e
-                          })
-                        }
-                      >
-                        {transitionStatus => {
-                          const mount =
-                            transitionStatus === "entering" ||
-                            transitionStatus === "entered";
+	render() {
+		const { props } = this
+		const { children, injectPageProps } = props
 
-                          const states = {
-                            entry: {
-                              state: entryState,
-                              delay: entryDelay,
-                              length: entryLength
-                            },
-                            exit: {
-                              state: exitState,
-                              delay: exitDelay,
-                              length: exitLength
-                            }
-                          };
+		return (
+			<Consumer>
+				{({
+					exitDelay,
+					exitLength,
+					exitState,
+					entryDelay,
+					entryLength,
+					entryState,
+					entryTrigger,
+					entryProps,
+					exitTrigger,
+					exitProps,
+					transitionIdHistory,
+					inTransition,
+					updateContext,
+					triggerResolve,
+					appearAfter,
+					e,
+				}) => {
+					return (
+						<Location>
+							{({ location: { action, pathname } }) => (
+								<Layout {...props}>
+									<div className="tl-edges">
+										<TransitionGroup component={null}>
+											<DelayedTransition
+												key={pathname} // we're using seconds but transitiongroup uses ms
+												delay={getMs(entryDelay)}
+												timeout={{
+													enter: getMs(entryLength),
+													exit: getMs(exitLength),
+												}}
+												onEnter={node =>
+													!!node &&
+													!window.__tl_back_button_pressed &&
+													onEnter({
+														node,
+														action,
+														inTransition,
+														entryTrigger,
+														entryProps,
+														exitProps,
+														pathname,
+														updateContext,
+														triggerResolve,
+														appearAfter: getMs(
+															appearAfter,
+														),
+														e,
+													})
+												}
+												onExit={node =>
+													!!node &&
+													!window.__tl_back_button_pressed &&
+													onExit({
+														node,
+														inTransition,
+														exitTrigger,
+														entryProps,
+														exitProps,
+														triggerResolve,
+														e,
+													})
+												}
+											>
+												{transitionStatus => {
+													const mount =
+														transitionStatus ===
+															"entering" ||
+														transitionStatus ===
+															"entered"
 
-                          const current = mount ? states.entry : states.exit;
+													const states = {
+														entry: {
+															state: entryState,
+															delay: entryDelay,
+															length: entryLength,
+														},
+														exit: {
+															state: exitState,
+															delay: exitDelay,
+															length: exitLength,
+														},
+													}
 
-                          const transitionState = returnTransitionState({
-                            inTransition,
-                            location: props.location,
-                            transitionIdHistory,
-                            transitionStatus,
-                            current,
-                            mount,
-                            ...states
-                          });
+													const current = mount
+														? states.entry
+														: states.exit
 
-                          const exitZindex = exitProps.zIndex || 0;
-                          const entryZindex = entryProps.zIndex || 1;
+													const transitionState = returnTransitionState(
+														{
+															inTransition,
+															location: props.location,
+															transitionIdHistory,
+															transitionStatus,
+															current,
+															mount,
+															...states,
+														},
+													)
 
-                          return (
-                            <TransitionRenderer
-                              mount={mount}
-                              entryZindex={entryZindex}
-                              exitZindex={exitZindex}
-                              transitionStatus={transitionStatus}
-                              transitionState={transitionState}
-                              children={children}
-                              appearAfter={getMs(appearAfter)}
-                            />
-                          );
-                        }}
-                      </DelayedTransition>
-                    </TransitionGroup>
-                  </div>
-                </Layout>
-              )}
-            </Location>
-          );
-        }}
-      </Consumer>
-    );
-  }
+													const exitZindex =
+														exitProps.zIndex || 0
+													const entryZindex =
+														entryProps.zIndex || 1
+
+													return (
+														<TransitionRenderer
+															mount={mount}
+															entryZindex={entryZindex}
+															exitZindex={exitZindex}
+															transitionStatus={
+																transitionStatus
+															}
+															transitionState={
+																transitionState
+															}
+															children={children}
+															injectPageProps={
+																injectPageProps
+															}
+															appearAfter={getMs(
+																appearAfter,
+															)}
+														/>
+													)
+												}}
+											</DelayedTransition>
+										</TransitionGroup>
+									</div>
+								</Layout>
+							)}
+						</Location>
+					)
+				}}
+			</Consumer>
+		)
+	}
 }

--- a/src/components/TransitionRenderer.js
+++ b/src/components/TransitionRenderer.js
@@ -1,63 +1,67 @@
-import React, { Component, cloneElement } from "react";
-import { setTimeout, clearTimeout } from "requestanimationframe-timer";
-import { PublicProvider } from "../context/createTransitionContext";
+import React, { Component, cloneElement } from "react"
+import { setTimeout, clearTimeout } from "requestanimationframe-timer"
+import { PublicProvider } from "../context/createTransitionContext"
 
 export default class TransitionRenderer extends Component {
-  state = {
-    shouldBeVisible: !!!this.props.appearAfter
-  };
+	state = {
+		shouldBeVisible: !!!this.props.appearAfter,
+	}
 
-  shouldComponentUpdate(nextProps, nextState) {
-    // only rerender if the transition status changes.
-    return (
-      this.props.transitionStatus !== nextProps.transitionStatus ||
-      this.state.shouldBeVisible !== nextState.shouldBeVisible
-    );
-  }
+	shouldComponentUpdate(nextProps, nextState) {
+		// only rerender if the transition status changes.
+		return (
+			this.props.transitionStatus !== nextProps.transitionStatus ||
+			this.state.shouldBeVisible !== nextState.shouldBeVisible
+		)
+	}
 
-  componentDidMount = () => {
-    const delay = typeof this.props.delay === "number" ? this.props.delay : 0;
-    const appearafter =
-      typeof this.props.appearAfter === "number" ? this.props.appearAfter : 0;
-    const timeout = delay + appearafter;
+	componentDidMount = () => {
+		const delay = typeof this.props.delay === "number" ? this.props.delay : 0
+		const appearafter =
+			typeof this.props.appearAfter === "number" ? this.props.appearAfter : 0
+		const timeout = delay + appearafter
 
-    this.appearTimeout = setTimeout(
-      () => this.setState({ shouldBeVisible: true }),
-      timeout
-    );
-  };
+		this.appearTimeout = setTimeout(
+			() => this.setState({ shouldBeVisible: true }),
+			timeout,
+		)
+	}
 
-  componentWillUnmount = () => {
-    clearTimeout(this.appearTimeout);
-  };
+	componentWillUnmount = () => {
+		clearTimeout(this.appearTimeout)
+	}
 
-  render() {
-    const {
-      mount,
-      entryZindex,
-      exitZindex,
-      transitionStatus,
-      transitionState,
-      children
-    } = this.props;
+	render() {
+		const {
+			mount,
+			entryZindex,
+			exitZindex,
+			transitionStatus,
+			transitionState,
+			children,
+			injectPageProps,
+		} = this.props
 
-    return (
-      <div
-        className={`tl-wrapper ${
-          mount ? "tl-wrapper--mount" : "tl-wrapper--unmount"
-        } tl-wrapper-status--${transitionStatus}`}
-        style={{
-          zIndex: mount ? entryZindex : exitZindex,
-          opacity: this.state.shouldBeVisible ? 1 : 0
-        }}
-      >
-        <PublicProvider value={{ ...transitionState }}>
-          {/* pass transition state to page/template */}
-          {cloneElement(children, {
-            ...transitionState
-          })}
-        </PublicProvider>
-      </div>
-    );
-  }
+		return (
+			<div
+				className={`tl-wrapper ${
+					mount ? "tl-wrapper--mount" : "tl-wrapper--unmount"
+				} tl-wrapper-status--${transitionStatus}`}
+				style={{
+					zIndex: mount ? entryZindex : exitZindex,
+					opacity: this.state.shouldBeVisible ? 1 : 0,
+				}}
+			>
+				<PublicProvider value={{ ...transitionState }}>
+					{/* pass transition state to page/template */}
+					{// injectPageProps is a plugin option
+					injectPageProps
+						? cloneElement(children, {
+								...transitionState,
+						  })
+						: children}
+				</PublicProvider>
+			</div>
+		)
+	}
 }

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -1,12 +1,14 @@
-const React = require("react");
-const TransitionHandler = require("./components/TransitionHandler").default;
-const InternalProvider = require("./context/InternalProvider").default;
+const React = require("react")
+const TransitionHandler = require("./components/TransitionHandler").default
+const InternalProvider = require("./context/InternalProvider").default
 
 // eslint-disable-next-line react/prop-types,react/display-name
-module.exports = ({ element, props }) => {
-  return (
-    <InternalProvider>
-      <TransitionHandler {...props}>{element}</TransitionHandler>
-    </InternalProvider>
-  );
-};
+module.exports = ({ element, props }, pluginOptions = { injectPageProps: true }) => {
+	return (
+		<InternalProvider>
+			<TransitionHandler {...props} {...pluginOptions}>
+				{element}
+			</TransitionHandler>
+		</InternalProvider>
+	)
+}


### PR DESCRIPTION
This allows disabling injecting page props by using a plugin option. By default this is set to true, in V2 it will default to false. Potentially fixes https://github.com/TylerBarnes/gatsby-plugin-transition-link/issues/148

```
    {
      resolve: 'gatsby-plugin-transition-link',
      options: {
        injectPageProps: false,
      },
    },
```