### PR TITLE
move default injectPageProps option so it gets applied properly

### DIFF
--- a/src/components/TransitionHandler.js
+++ b/src/components/TransitionHandler.js
@@ -17,7 +17,7 @@ const DelayedTransition = delayTransitionRender(Transition)
 export default class TransitionHandler extends Component {
 	render() {
 		const { props } = this
-		const { children, injectPageProps } = props
+		const { children, injectPageProps = true } = props
 
 		return (
 			<Consumer>

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -3,7 +3,7 @@ const TransitionHandler = require("./components/TransitionHandler").default
 const InternalProvider = require("./context/InternalProvider").default
 
 // eslint-disable-next-line react/prop-types,react/display-name
-module.exports = ({ element, props }, pluginOptions = { injectPageProps: true }) => {
+module.exports = ({ element, props }, pluginOptions) => {
 	return (
 		<InternalProvider>
 			<TransitionHandler {...props} {...pluginOptions}>


### PR DESCRIPTION
closes https://github.com/TylerBarnes/gatsby-plugin-transition-link/issues/150 and https://github.com/TylerBarnes/gatsby-plugin-transition-link/issues/145