### PR TITLE
fix: paintdrip timing

### DIFF
--- a/src/AniLink/PaintDrip.js
+++ b/src/AniLink/PaintDrip.js
@@ -61,7 +61,12 @@ export default class PaintDrip extends Component {
         { radius: radius, ease: Power1.easeIn },
         0
       )
-      .to(canvas, seconds / 3, { x: "100%", ease: Power1.easeIn }, `+=.2`);
+      .to(
+        canvas,
+        seconds / 3,
+        { x: "100%", ease: Power1.easeIn },
+        `+=${seconds * 0.4}`
+      )
 
     function drawRipple() {
       ctx.clearRect(0, 0, vw, vh);

--- a/src/AniLink/PaintDrip.js
+++ b/src/AniLink/PaintDrip.js
@@ -54,7 +54,7 @@ export default class PaintDrip extends Component {
       onComplete: () => removeCanvas(seconds / 3)
     })
       .to(ripple, seconds / 4, { alpha: 1 })
-      .set(node, { visibility: "hidden" }, seconds / 1.75)
+      .set(node, { visibility: "hidden" })
       .to(
         ripple,
         seconds - seconds / 3,


### PR DESCRIPTION
closes https://github.com/TylerBarnes/gatsby-plugin-transition-link/issues/148