### PR TITLE
fix: hide the exiting page contents once the cover div is covering the screen

### DIFF
--- a/src/AniLink/Cover.js
+++ b/src/AniLink/Cover.js
@@ -25,6 +25,7 @@ export default class Cover extends Component {
 				x: '0%',
 				ease: Power1.easeInOut,
 			})
+			.set(node, { opacity: 0 })
 			.to(
 				this.cover,
 				half,


### PR DESCRIPTION
fixes #84