### PR TITLE
Fix updating transition renderer component

### DIFF
--- a/src/components/TransitionRenderer.js
+++ b/src/components/TransitionRenderer.js
@@ -11,7 +11,8 @@ export default class TransitionRenderer extends Component {
 		// only rerender if the transition status changes.
 		return (
 			this.props.transitionStatus !== nextProps.transitionStatus ||
-			this.state.shouldBeVisible !== nextState.shouldBeVisible
+			this.state.shouldBeVisible !== nextState.shouldBeVisible ||
+			this.props.children !== nextProps.children
 		)
 	}
 


### PR DESCRIPTION
Hello!

In my gatsby app, data is being updated frequently, but HMR wasn't working fine. I've started to search for the reason why it is broken and found that when the data is updated, it's being stuck in `TransitionRenderer` component.

`wrap-page` is wrapping each gatsby page with its own layout, and render children inside it. Children here are the gatsby page itself.
`TransitionRenderer` has implemented `shouldComponentUpdate` with checks which are required, but it's not checking also for children - has they been updated or not. So the page is never gets updated until it's refreshed. 

I've added to `shouldComponentUpdate` this check, and it fixes HMR back to normal.